### PR TITLE
Use Arduino.h (not arduino.h) on case sensitive filesystems (non-windows)

### DIFF
--- a/src/digitalPinFast.h
+++ b/src/digitalPinFast.h
@@ -2,8 +2,9 @@
 #define DIGITAL_PIN_FAST_h
 
 #include <stdint.h>
-#include "arduino.h"
-#include "pins_arduino.h"
+
+#include <Arduino.h>
+#include <pins_arduino.h>
 
 class digitalPinFast {
 private:


### PR DESCRIPTION
Also, prefer `<>`-includes for libraries (including Arduino libraries) and `""`-includes only for files expected in the project source tree.

Without this fix, "arduino.h" is not found (because it's called "Arduino.h").

As for the `<>`-change: if I look at most other libraries in my libraries-dir, `<Arduino.h>` looks like the preferred way.